### PR TITLE
Add extra vimrc fiel to overwrite configuration locally

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -441,7 +441,7 @@ vnoremap ar a[
 " }}}
 
 " Extra vimrc {{{
-let s:extrarc = expand($HOME . '/.extra.vimrc')
+let s:extrarc = expand($HOME . '/.vim/local.vimrc')
 if filereadable(s:extrarc)
     exec ':so ' . s:extrarc
 endif


### PR DESCRIPTION
It allows you to pu something in ~/.vim/local.vimrc to be loaded at the end to overwrite the configuration that you don't like. For me it's neocomplcache.
