### PR TITLE
delted map Y

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -191,8 +191,6 @@ match ErrorMsg '^\(<\|=\|>\)\{7\}\([^=].\+\)\?$'
 
 " Mappings {{{
 
-map Y y$
-
 " bracket match using tab
 map <tab> %
 


### PR DESCRIPTION
IMO `map Y y$` is very personal setting, that changes behaviour of one of vims fundamentals binding. In my opinion it should be set by you in `local.vimrc` or `after.vimrc`. Merge if you agree, I have to delete it in my branch, as I love default `Y` behaviour.
