### PR TITLE
Remove hammer.vim.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,6 @@ Vim plugin for the Perl module / CLI script 'ack'.
 
 **Command**: `,a` 
 
-#### [hammer](https://github.com/matthias-guenther/hammer.vim)
-
-vim, your markup language of choice, and your browser of choice. 
-
-**Command**: `,p` 
-
 #### [vim-fugitive](https://github.com/tpope/vim-fugitive)
 
 fugitive.vim: a Git wrapper so awesome, it should be illegal 

--- a/vimrc
+++ b/vimrc
@@ -40,9 +40,6 @@ if count(g:vimified_packages, 'general')
     Bundle "mileszs/ack.vim"
     nnoremap <leader>a :Ack!<space>
 
-    Bundle 'matthias-guenther/hammer.vim' 
-    nmap <leader>p :Hammer<cr>
-
     Bundle 'tsaleh/vim-align'
     Bundle 'tpope/vim-endwise'
     Bundle 'tpope/vim-repeat'


### PR DESCRIPTION
I've tried to get it to work for the simplest use case - markdown files, but failed. I've installed the github-markup, tilt, coderay and redcloth gems, but still got a "Cannot render a .md file. Missing renderer?".

Judging by the overwritten mapping for hammer.vim, you're not using it anyway. I'd remove that, as for me the cost of getting it to work is higher then any possible benefit I might have from previewing files as HTML.

Or, figure out a smart way to handle all the gem dependencies and describe it in the documenation.
