### PR TITLE
Update README.md to correct command trigger for nerdcommenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ gitk for Vim.
 
 Vim plugin for intensely orgasmic commenting.
 
-**Command:** `,/`
+**Command:** `,#`
 
 #### [splice.vim](https://github.com/sjl/splice.vim)
 


### PR DESCRIPTION
command trigger for nerdcommenter was <leader>/ but infact was <leader># in vimrc file.
