### PR TITLE
Readd the proper bundle source for vim-matchit

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -71,6 +71,7 @@ if count(g:vimified_packages, 'general')
     Bundle 'michaeljsmith/vim-indent-object'
     let g:indentobject_meaningful_indentation = ["haml", "sass", "python", "yaml", "markdown"]
 
+    Bundle 'Spaceghost/vim-matchit'
     Bundle 'kien/ctrlp.vim'
     Bundle 'vim-scripts/scratch.vim'
 


### PR DESCRIPTION
It was a missing depndency for vim-ruby-refactoring.
