### PR TITLE
Only remap shell if zsh is there

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -318,7 +318,9 @@ set noeol
 set relativenumber
 set numberwidth=10
 set ruler
-set shell=/bin/zsh
+if executable('/bin/zsh')
+  set shell=/bin/zsh
+endif
 set showcmd
 
 set exrc


### PR DESCRIPTION
Using vimified on systems without zsh results in sad times :-/
