### PR TITLE
Use a different space character, improve consistency

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -298,7 +298,7 @@ set nolazyredraw
 " Disable the macvim toolbar
 set guioptions-=T
 
-set listchars=tab:▸\ ,eol:¬,extends:❯,precedes:❮
+set listchars=tab:▸\ ,eol:¬,extends:❯,precedes:❮,trail:␣
 set showbreak=↪
 
 set notimeout
@@ -373,8 +373,8 @@ augroup END
 " Only shown when not in insert mode so I don't go insane.
 augroup trailing
     au!
-    au InsertEnter * :set listchars-=trail:⌴
-    au InsertLeave * :set listchars+=trail:⌴
+    au InsertEnter * :set listchars-=trail:␣
+    au InsertLeave * :set listchars+=trail:␣
 augroup END
 
 " Remove trailing whitespaces when saving


### PR DESCRIPTION
This one is a little controversial. The new 'space' character is more-compatible with various fonts I've tried out, specifically with fonts on windows.

Additionally, I made it so that when you open a new file (i.e. you're in normal mode), the trailing space character shows up. Otherwise it's not there, but then magically appears when you enter/leave insert mode.
