### PR TITLE
Fixes wrong yankring_history_dir

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -68,7 +68,7 @@ if count(g:vimified_packages, 'general')
     Bundle 'vim-scripts/YankRing.vim'
     let g:yankring_replace_n_pkey = '<leader>['
     let g:yankring_replace_n_nkey = '<leader>]'
-    let g:yankring_history_dir = '~/.vim/tmp'
+    let g:yankring_history_dir = '~/.vim/tmp/'
     nmap <leader>y :YRShow<cr>
 
     Bundle 'michaeljsmith/vim-indent-object'


### PR DESCRIPTION
Fixes wrong yankring history dir settings.

``` bash
> Error detected while processing function <SNR>45_YRInit..<SNR>45_YRHistoryRead..<SNR>45_YRHistorySave: 
line    8:
E482: Can't create file /yankring_history_v2.txt
YRHistorySave: Unable to save yankring history file: /yankring_history_v2.txt
```
