### PR TITLE
Fix the repo and loading of powerline

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -85,8 +85,7 @@ endif
 
 " _. Fancy {{{
 if count(g:vimified_packages, 'fancy')
-    Bundle 'Lokaltog/powerline'
-    python from powerline.ext.vim import source_plugin; source_plugin()
+    Bundle 'Lokaltog/vim-powerline'
 endif
 " }}}
 


### PR DESCRIPTION
As you might now, the vim-powerline plugin is deprecated in favour of
the new omnipotent [powerline plugin](https://github.com/Lokaltog/powerline). Right now it's in beta, but
until now it seems to work without issues.

Prolly it could be a good idea, to wait a bit to merge this in the
master branch.
