### PR TITLE
More flexible install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,28 +1,30 @@
 #!/usr/env sh
 
+INSTALLDIR=$PWD
+
 create_symlinks () {
     if [ ! -f ~/.vim ]; then
         echo "Now, we will create ~/.vim and ~/.vimrc files to configure Vim."
-        ln -sfn vimified ~/.vim
+        ln -sfn $INSTALLDIR/vimified ~/.vim
     fi
 
     if [ ! -f ~/.vimrc ]; then
-        ln -sfn vimified/vimrc ~/.vimrc
+        ln -sfn $INSTALLDIR/vimified/vimrc ~/.vimrc
     fi
   }
 
 echo "Welcome friend!"
 echo "You are about to be vimified. Ready? Let us do the stuff for you."
 
-if [ ! -d "vimified" ]; then
+if [ ! -d "$INSTALLDIR/vimified" ]; then
     echo "As we can't find Vimified in the current directory, we will create it."
     git clone git://github.com/zaiste/vimified.git
     create_symlinks
-    cd vimified
+    cd $INSTALLDIR/vimified
 
 else
     echo "Seems like you already are one of ours, so let's update Vimified to be as awesome as possible."
-    cd vimified
+    cd $INSTALLDIR/vimified
     git pull origin master
     create_symlinks
 fi


### PR DESCRIPTION
The installer (install.sh) expects the folder "vimified" located in $HOME. If the installer is called from another location, then the symlinks do not work.

This patch defines a environment variable INSTALLDIR, that contains the path of the current folder ($PWD). Now the soft links reference the absolute path to the "vimified" folder.

Feel free to skip this patch and implement these absolute pathes otherways. But please make the installer more robust.
