### PR TITLE
Use an existing colorscheme in vimrc 

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -251,6 +251,10 @@ if count(g:vimified_packages, 'color')
     Bundle 'zaiste/Atom'
     Bundle 'w0ng/vim-hybrid'
     Bundle 'chriskempson/base16-vim'
+
+    colorscheme molokai
+else
+    colorscheme default
 endif
 " }}}
 
@@ -258,7 +262,6 @@ endif
 
 " General {{{
 filetype plugin indent on
-colorscheme Tomorrow-Night
 
 syntax on
 


### PR DESCRIPTION
If the package "color" is enabled, then use the molokai.colortheme, otherwise use default.colortheme as delivered with stock vim distribution.
