### PR TITLE
Check for git and vim before running the install.sh script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,18 @@ create_symlinks () {
 echo "Welcome friend!"
 echo "You are about to be vimified. Ready? Let us do the stuff for you."
 
+which git > /dev/null
+if [ "$?" != "0" ]; then
+  echo "You need git installed to install vimified."
+  exit 1
+fi
+
+which vim > /dev/null
+if [ "$?" != "0" ]; then
+  echo "You need vim installed to install vimified."
+  exit 1
+fi
+
 if [ ! -d "$INSTALLDIR/vimified" ]; then
     echo "As we can't find Vimified in the current directory, we will create it."
     git clone git://github.com/zaiste/vimified.git


### PR DESCRIPTION
When I deploy "vimified" on a  new machine, then it happens regulary, that "git" or "vim" are not installed (recently a box running "Ubuntu 12.04 LTS").

I added a check for "git" and "vim" in the $PATH.
