### PR TITLE
Use default colorscheme during installation.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -265,7 +265,12 @@ if count(g:vimified_packages, 'color')
     Bundle 'Elive/vim-colorscheme-elive'
     Bundle 'zeis/vim-kolor'
 
-    colorscheme molokai
+    " During installation the molokai colorscheme might not be avalable
+    if filereadable(globpath(&rtp, 'colors/molokai.vim'))
+      colorscheme molokai
+    else
+      colorscheme default
+    endif
 else
     colorscheme default
 endif


### PR DESCRIPTION
During installation the bundle "tomasr/molokai" is not available, even if the package "color" is activated. Thus in this case the colorscheme "default" should be set.
