### PR TITLE
Replace Ack with The Silver Searcher / ag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Avaible packages:
 
 ### General
 
-#### [ack.vim](http://github.com/mileszs/ack.vim)
+#### [ag.vim](https://github.com/rking/ag.vim)
 
-Vim plugin for the Perl module / CLI script 'ack'.
+Vim plugin for the_silver_searcher, 'ag', a replacement for the Perl module
+/ CLI script 'ack'
 
 **Command**: `,a`
 

--- a/vimrc
+++ b/vimrc
@@ -51,8 +51,8 @@ endif
 
 " _. General {{{
 if count(g:vimified_packages, 'general')
-    Bundle "mileszs/ack.vim"
-    nnoremap <leader>a :Ack!<space>
+    Bundle 'rking/ag.vim'
+    nnoremap <leader>a :Ag<space>
 
     Bundle 'matthias-guenther/hammer.vim'
     nmap <leader>p :Hammer<cr>


### PR DESCRIPTION
Reason: http://geoff.greer.fm/2011/12/27/the-silver-searcher-better-than-ack/

Of course, needs you to brew install ag to work.
