### PR TITLE
filetype on before filetype off, for git&svn comment editing.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -6,6 +6,7 @@
 "
 "
 set nocompatible
+filetype on
 filetype off
 
 " Load external configuration before anything else {{{


### PR DESCRIPTION
When using vimified, vim may exit with code 1 after :wq.
Usually, it is not a big problem.
But when using vim to write git/svn commit message, it always failed for the exit code of vim.
After a lot of checking and googling, it turns out that vim will exit with 1 when .vimrc setup 'filetype off' before turn on filetype switch.
So, turn it on first and then turn it off.
Everything is fine now.
