### PR TITLE
improv: set shell to ZSH in interactive mode

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -401,7 +401,7 @@ set numberwidth=3
 set winwidth=83
 set ruler
 if executable('/bin/zsh')
-  set shell=/bin/zsh
+  set shell=/bin/zsh\ -i
 endif
 set showcmd
 


### PR DESCRIPTION
In interactive mode, ZSH will read `~/.zshrc`. Else, it will first stick to
`/etc/zshenv`, then `/etc/zprofile` and last to `.zshrc`. Without this, running
shell command from within Vim may result in `command not found`.
