### PR TITLE
Check to see if zsh is even used

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -400,8 +400,11 @@ endif
 set numberwidth=3
 set winwidth=83
 set ruler
-if executable('/bin/zsh')
-  set shell=/bin/zsh\ -i
+" Check to see if zsh is even used
+if filereadable(expand("~/.zshrc"))
+  if executable('/bin/zsh')
+    set shell=/bin/zsh\ -i
+  endif
 endif
 set showcmd
 


### PR DESCRIPTION
Last commit (9569441) was breaking my vim.  Whenever I try to start vim it just would segfault. 

$ vim
[1]+ Stopped vim

If I take out this change by removing the "\ -i" vim starts up fine.

I don't use zsh so not sure if that has anything to do with it.  My pull request checks to see if the user is even using zsh by checking the presence of a .zshrc file.
