### PR TITLE
Latest VIM introduces stricter funtion names, this patch fixes them

### DIFF
--- a/functions/util.vim
+++ b/functions/util.vim
@@ -1,4 +1,4 @@
-function! g:check_defined(variable, default)
+function! g:Check_defined(variable, default)
   if !exists(a:variable)
     let {a:variable} = a:default
   endif

--- a/vimrc
+++ b/vimrc
@@ -107,9 +107,9 @@ endif
 
 " _. Fancy {{{
 if count(g:vimified_packages, 'fancy')
-    call g:check_defined('g:airline_left_sep', '')
-    call g:check_defined('g:airline_right_sep', '')
-    call g:check_defined('g:airline_branch_prefix', '')
+    call g:Check_defined('g:airline_left_sep', '')
+    call g:Check_defined('g:airline_right_sep', '')
+    call g:Check_defined('g:airline_branch_prefix', '')
 
     Bundle 'bling/vim-airline'
 endif


### PR DESCRIPTION
Starting in VIM version  v7.4.260 there were some changes done to be more strict about what
can be used in function names.

If you upgrade you might run into issues with another vim plugin, you will need this PR until it get's fixed.

https://github.com/BlackIkeEagle/vdebug/commit/ce92c9fe602a6a336bd814499894b5d18f32dc6c
