### PR TITLE
Remove mappings that overwrite default vim functions

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -77,7 +77,6 @@ if count(g:vimified_packages, 'general')
     Bundle 'tpope/vim-eunuch'
 
     Bundle 'scrooloose/nerdtree'
-    nmap <C-i> :NERDTreeToggle<CR>
     " Disable the scrollbars (NERDTree)
     set guioptions-=r
     set guioptions-=L

--- a/vimrc
+++ b/vimrc
@@ -558,10 +558,6 @@ nnoremap <silent> <leader>h3 :execute '3match InterestingWord3 /\<<c-r><c-w>\>/'
 
 " Navigation & UI {{{
 
-" Begining & End of line in Normal mode
-noremap H ^
-noremap L g_
-
 " more natural movement with wrap on
 nnoremap j gj
 nnoremap k gk


### PR DESCRIPTION
1. Overwrites a default vim binding of H as top line in the window
and Las bottom line in the window. Beginning and end of line are
available anyway as 0 and $ anyway.

2. Overwrites the default binding of C-i as a C-o counterpart for navigation through jump history. C-i/o are really useful and feels weird having one, but not the other. Also, you can open NERDTree easily with the tab shortcut anyway.