### PR TITLE
Update the vim-virtualenv bundle to github.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -192,7 +192,7 @@ if count(g:vimified_packages, 'python')
     Bundle 'python.vim'
     Bundle 'python_match.vim'
     Bundle 'pythoncomplete'
-    Bundle 'vim-virtualenv'
+    Bundle 'jmcantrell/vim-virtualenv'
 endif
 " }}}
 


### PR DESCRIPTION
This script may have been located on vim.org but now it seems to
only be on Github.

I added the author's github account to the bundle name so it finds
it now.