### PR TITLE
colorize command when ^xe is entered in bash

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -137,6 +137,8 @@ if count(g:vimified_packages, 'os')
     map <Leader>rl :VimuxRunLastCommand<CR>
 
     map <LocalLeader>d :call VimuxRunCommand(@v, 0)<CR>
+    au! BufNewFile,BufRead /tmp/bash-fc-* setfiletype sh
+
 endif
 " }}}
 


### PR DESCRIPTION
if EDITOR=vim, and type ^xe in bash, you will get the input typed until the moment inside vim. 
This line set the filetype to the file that contains the command